### PR TITLE
User double team fix

### DIFF
--- a/src/controllers/team.controller.js
+++ b/src/controllers/team.controller.js
@@ -84,6 +84,15 @@ exports.joinTeam = async (req, res) => {
     if (existError) return res.status(500).json({ error: existError.message });
     if (existing)
       return res.status(400).json({ error: 'Already in this team' });
+    //checking if user is already in another team
+    const { data: otherTeam, error: otherError } = await supabase
+      .from('TeamPlayer')
+      .select('id')
+      .eq('userId', userId)
+      .maybeSingle();
+    if (otherError) return res.status(500).json({ error: otherError.message });
+    if (otherTeam)
+      return res.status(400).json({ error: 'Already in another team' });
 
     const { error: addError } = await supabase
       .from('TeamPlayer')


### PR DESCRIPTION
This pull request updates the team joining logic to prevent a user from joining multiple teams. The main change is an additional check in the `joinTeam` controller to ensure a user is not already a member of another team before allowing them to join a new one.

**Team membership validation:**

* Added a check in `joinTeam` (`src/controllers/team.controller.js`) to return an error if the user is already a member of any team, preventing users from joining multiple teams.